### PR TITLE
Added initial draft of a piece context menu

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
-	rl "github.com/gen2brain/raylib-go/raylib"
 	"math/rand"
+
+	rl "github.com/gen2brain/raylib-go/raylib"
+
+	rg "github.com/gen2brain/raylib-go/raygui"
 )
-import rg "github.com/gen2brain/raylib-go/raygui"
 
 func main() {
 	rl.SetConfigFlags(rl.FlagWindowResizable)
@@ -55,6 +57,21 @@ func main() {
 }
 
 func handleBoardInteraction(ui *UIState) {
+	handleMouseInteraction(ui)
+
+	if pieceId, ok := selection.GetSelectedPieceId(); ok {
+		if rl.IsKeyPressed(rl.KeyDelete) || rl.IsKeyPressed(rl.KeyBackspace) {
+			sandbox.RemovePiece(pieceId)
+		}
+	}
+}
+
+func handleMouseInteraction(ui *UIState) {
+	// Don't handle mouse events when clicking inside the right hand side panel
+	if rl.GetMousePosition().X > float32(rl.GetScreenWidth()-UiRightMenuWidth) {
+		return
+	}
+
 	if rl.IsMouseButtonPressed(rl.MouseButtonLeft) {
 		var coord = GetHoveredCoord()
 		var piece = sandbox.GetPieceAt(coord)
@@ -69,8 +86,6 @@ func handleBoardInteraction(ui *UIState) {
 			var coord = GetHoveredCoord()
 			var piece = sandbox.GetPiece(id)
 			piece.coord = coord
-		} else if rl.IsKeyPressed(rl.KeyDelete) || rl.IsKeyPressed(rl.KeyBackspace) {
-			sandbox.RemovePiece(id)
 		}
 	} else if ui.anyPieceSelected {
 		if rl.IsMouseButtonPressed(rl.MouseButtonRight) {

--- a/sandbox.go
+++ b/sandbox.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	rl "github.com/gen2brain/raylib-go/raylib"
 	"sort"
+
+	rl "github.com/gen2brain/raylib-go/raylib"
 )
 
 var sandbox = Sandbox{}
@@ -107,15 +108,7 @@ func (s *Sandbox) RemovePiece(id uint32) bool {
 		return false
 	}
 
-	// Remove status effects on this piece
-	var removedEffects = 0
-	for i := len(s.effects) - 1; i >= 0; i-- {
-		if s.effects[i].piece == id {
-			removedEffects++
-			s.effects[i] = s.effects[len(s.effects)-removedEffects]
-		}
-	}
-	s.effects = s.effects[:len(s.effects)-removedEffects]
+	s.RemoveEffectsFromPiece(id)
 
 	// The slice is unordered, so we insert the last Piece where there removed Piece was and shorten the slice
 	for i := 0; i < len(s.pieces); i++ {
@@ -126,6 +119,17 @@ func (s *Sandbox) RemovePiece(id uint32) bool {
 		}
 	}
 	return false
+}
+
+func (s *Sandbox) RemoveEffectsFromPiece(pieceId uint32) {
+	var removedEffects = 0
+	for i := len(s.effects) - 1; i >= 0; i-- {
+		if s.effects[i].piece == pieceId {
+			removedEffects++
+			s.effects[i] = s.effects[len(s.effects)-removedEffects]
+		}
+	}
+	s.effects = s.effects[:len(s.effects)-removedEffects]
 }
 
 func (s *Sandbox) GetPieceAt(coord Vec2) *Piece {
@@ -151,6 +155,16 @@ func (s *Sandbox) GetStatusEffectType(id uint32) *StatusEffectType {
 	return &s.effectTypes[id]
 }
 
+func (s *Sandbox) GetStatusEffectCount(pieceId uint32, statusType uint32) int {
+	var count = 0
+	for _, effect := range sandbox.effects {
+		if effect.typ == statusType && effect.piece == pieceId {
+			count++
+		}
+	}
+	return count
+}
+
 func (s *Sandbox) GetStatusEffectTypeByName(name string) *StatusEffectType {
 	for i := 0; i < len(s.effectTypes); i++ {
 		if s.effectTypes[i].name == name {
@@ -166,6 +180,15 @@ func (s *Sandbox) NewStatusEffect(piece uint32, typ uint32) *StatusEffect {
 		typ:   typ,
 	})
 	return &s.effects[len(s.effects)-1]
+}
+
+func (s *Sandbox) RemoveStatusEffect(piece uint32, typ uint32) {
+	for i, effect := range s.effects {
+		if effect.typ == typ && effect.piece == piece {
+			s.effects = append(s.effects[:i], s.effects[i+1:]...)
+			return
+		}
+	}
 }
 
 func (s *Sandbox) RegisterObstacleType(name string, tex rl.Texture2D) *ObstacleType {

--- a/selection.go
+++ b/selection.go
@@ -33,3 +33,7 @@ func (s *Selection) GetSelectedPieceId() (uint32, bool) {
 	}
 	return s.id, true
 }
+
+func (s *Selection) HasSelection() bool {
+	return s.typ != SelectionTypeNone
+}

--- a/ui.go
+++ b/ui.go
@@ -1,16 +1,19 @@
 package main
 
 import (
+	"fmt"
+	"math/rand"
+
 	rg "github.com/gen2brain/raylib-go/raygui"
 	rl "github.com/gen2brain/raylib-go/raylib"
-	"math/rand"
 )
 
 const (
-	UiMargin      = 20
-	UiMarginSmall = 10
-	UiMarginBig   = 40
-	UiButtonH     = 36
+	UiMargin         = 20
+	UiMarginSmall    = 10
+	UiMarginBig      = 40
+	UiButtonH        = 36
+	UiRightMenuWidth = 155
 )
 
 type UIState struct {
@@ -36,14 +39,20 @@ func (s *UIState) Render() {
 		}
 	}
 
+	rg.Panel(rl.NewRectangle(float32(rl.GetScreenWidth())-UiRightMenuWidth, 0, UiRightMenuWidth, float32(rl.GetScreenHeight())), "")
+
 	s.board = rg.ToggleGroup(rl.NewRectangle(float32(rl.GetScreenWidth()/2-(120*3+int(rg.GetStyle(rg.DEFAULT, rg.GROUP_PADDING)))/2), float32(rl.GetScreenHeight()-UiButtonH-UiMargin), 120, UiButtonH), "Heaven;Earth;Hell", s.board)
 
-	s.tab = rg.ToggleGroup(rl.NewRectangle(float32(rl.GetScreenWidth()-UiMargin-2*UiButtonH-2*int(rg.GetStyle(rg.DEFAULT, rg.GROUP_PADDING))), UiMargin, UiButtonH, UiButtonH), "#149#;#157#;#97#", s.tab)
-
-	if s.tab == 0 {
-		s.RenderPiecesTab()
+	if selection.HasSelection() {
+		s.RenderPieceContextMenu()
 	} else {
-		s.anyPieceSelected = false
+		s.tab = rg.ToggleGroup(rl.NewRectangle(float32(rl.GetScreenWidth()-UiMargin-2*UiButtonH-2*int(rg.GetStyle(rg.DEFAULT, rg.GROUP_PADDING))), UiMargin+5, UiButtonH, UiButtonH), "#149#;#157#;#97#", s.tab)
+
+		if s.tab == 0 {
+			s.RenderPiecesTab()
+		} else {
+			s.anyPieceSelected = false
+		}
 	}
 }
 
@@ -55,5 +64,33 @@ func (s *UIState) RenderPiecesTab() {
 			s.anyPieceSelected = true
 			s.piece = uint32(i)
 		}
+	}
+}
+
+func (s *UIState) RenderPieceContextMenu() {
+	var selectedPiece, _ = selection.GetSelectedPieceId()
+
+	for i, effect := range sandbox.effectTypes {
+		var iconPosX = int32(rl.GetScreenWidth()) - 85
+		var iconPosY = int32(i*75 + 50)
+		rl.DrawTexture(effect.tex, iconPosX, iconPosY, rl.White)
+
+		var effectCount = sandbox.GetStatusEffectCount(selectedPiece, effect.id)
+		rl.DrawText(fmt.Sprint(effectCount), iconPosX+5, iconPosY+25, 16, rl.Black)
+		if rg.Button(rl.NewRectangle(float32(iconPosX-55), float32(iconPosY), 40, 30), "--") && effectCount > 0 {
+			sandbox.RemoveStatusEffect(selectedPiece, effect.id)
+		}
+		if rg.Button(rl.NewRectangle(float32(iconPosX+35), float32(iconPosY), 40, 30), "++") {
+			sandbox.NewStatusEffect(selectedPiece, effect.id)
+		}
+	}
+
+	var posX = float32(rl.GetScreenWidth() - UiRightMenuWidth + UiMarginSmall)
+	var posY = float32(rl.GetScreenHeight() - UiMarginSmall - 40)
+	var width = float32(rl.GetScreenWidth() - int(posX) - UiMarginSmall)
+	var height float32 = 40
+	if rg.Button(rl.NewRectangle(posX, posY, width, height), "Remove piece") {
+		sandbox.RemovePiece(selectedPiece)
+		selection.Deselect()
 	}
 }


### PR DESCRIPTION
Added a context menu for when a piece is selected to control status effects and a mouse only delete option

Might not have been the initial design, but It felt natural when I was working on it
<img width="869" alt="image" src="https://github.com/NicEastvillage/ChessHeavenAndHell/assets/10059450/26dceb81-de2b-4221-b8d0-e7bd40d9032f">

When no piece is selected we switch back to the add things menu
<img width="129" alt="image" src="https://github.com/NicEastvillage/ChessHeavenAndHell/assets/10059450/76e2d71d-e4da-49e2-993b-e5804ed055e6">

fixed #10 
fixed #8 

