### PR TITLE
Add money and shop

### DIFF
--- a/command.go
+++ b/command.go
@@ -1,5 +1,7 @@
 package main
 
+import "math/rand"
+
 type CreatePieceCmd struct {
 	piece             Piece
 	anyCaptured       bool
@@ -35,6 +37,7 @@ func (cmd *CreatePieceCmd) redo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(cmd.piece.board)
 	}
 	ui.selection.Deselect()
+	ui.showShop = false
 }
 
 func (cmd *CreatePieceCmd) undo(sb *Sandbox, ui *UiState) {
@@ -51,6 +54,7 @@ func (cmd *CreatePieceCmd) undo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(cmd.piece.board)
 	}
 	ui.selection.Deselect()
+	ui.showShop = false
 }
 
 type DeletePieceCmd struct {
@@ -77,6 +81,7 @@ func (cmd *DeletePieceCmd) redo(sb *Sandbox, ui *UiState) {
 	if cmd.piece.board != OffBoard {
 		ui.board = int32(cmd.piece.board)
 	}
+	ui.showShop = false
 }
 
 func (cmd *DeletePieceCmd) undo(sb *Sandbox, ui *UiState) {
@@ -88,6 +93,7 @@ func (cmd *DeletePieceCmd) undo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(cmd.piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece.id)
+	ui.showShop = false
 }
 
 type MovePieceCmd struct {
@@ -142,6 +148,7 @@ func (cmd *MovePieceCmd) redo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
 }
 
 func (cmd *MovePieceCmd) undo(sb *Sandbox, ui *UiState) {
@@ -157,6 +164,7 @@ func (cmd *MovePieceCmd) undo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
 }
 
 type CreateStatusEffectCmd struct {
@@ -179,6 +187,7 @@ func (cmd *CreateStatusEffectCmd) redo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
 }
 
 func (cmd *CreateStatusEffectCmd) undo(sb *Sandbox, ui *UiState) {
@@ -188,6 +197,7 @@ func (cmd *CreateStatusEffectCmd) undo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
 }
 
 type DeleteStatusEffectCmd struct {
@@ -210,6 +220,7 @@ func (cmd *DeleteStatusEffectCmd) redo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
 }
 
 func (cmd *DeleteStatusEffectCmd) undo(sb *Sandbox, ui *UiState) {
@@ -219,6 +230,7 @@ func (cmd *DeleteStatusEffectCmd) undo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
 }
 
 type IncreasePieceScaleCmd struct {
@@ -239,6 +251,7 @@ func (cmd *IncreasePieceScaleCmd) redo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
 }
 
 func (cmd *IncreasePieceScaleCmd) undo(sb *Sandbox, ui *UiState) {
@@ -248,6 +261,7 @@ func (cmd *IncreasePieceScaleCmd) undo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
 }
 
 type DecreasePieceScaleCmd struct {
@@ -268,6 +282,7 @@ func (cmd *DecreasePieceScaleCmd) redo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
 }
 
 func (cmd *DecreasePieceScaleCmd) undo(sb *Sandbox, ui *UiState) {
@@ -277,6 +292,7 @@ func (cmd *DecreasePieceScaleCmd) undo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
 }
 
 type CreateTileCmd struct {
@@ -296,12 +312,14 @@ func (cmd *CreateTileCmd) redo(sb *Sandbox, ui *UiState) {
 	sb.NewTile(cmd.board, cmd.coord)
 	ui.board = int32(cmd.board)
 	ui.selection.SelectCoord(cmd.coord)
+	ui.showShop = false
 }
 
 func (cmd *CreateTileCmd) undo(sb *Sandbox, ui *UiState) {
 	sb.RemoveTile(cmd.board, cmd.coord)
 	ui.board = int32(cmd.board)
 	ui.selection.SelectCoord(cmd.coord)
+	ui.showShop = false
 }
 
 type DeleteTileCmd struct {
@@ -321,12 +339,14 @@ func (cmd *DeleteTileCmd) redo(sb *Sandbox, ui *UiState) {
 	sb.RemoveTile(cmd.board, cmd.coord)
 	ui.board = int32(cmd.board)
 	ui.selection.SelectCoord(cmd.coord)
+	ui.showShop = false
 }
 
 func (cmd *DeleteTileCmd) undo(sb *Sandbox, ui *UiState) {
 	sb.NewTile(cmd.board, cmd.coord)
 	ui.board = int32(cmd.board)
 	ui.selection.SelectCoord(cmd.coord)
+	ui.showShop = false
 }
 
 type CreateObstacleCmd struct {
@@ -348,12 +368,14 @@ func (cmd *CreateObstacleCmd) redo(sb *Sandbox, ui *UiState) {
 	sb.NewObstacle(cmd.coord, cmd.board, cmd.obstacle)
 	ui.board = int32(cmd.board)
 	ui.selection.SelectCoord(cmd.coord)
+	ui.showShop = false
 }
 
 func (cmd *CreateObstacleCmd) undo(sb *Sandbox, ui *UiState) {
 	sb.RemoveObstacle(cmd.coord, cmd.board, cmd.obstacle)
 	ui.board = int32(cmd.board)
 	ui.selection.SelectCoord(cmd.coord)
+	ui.showShop = false
 }
 
 type DeleteObstacleCmd struct {
@@ -375,12 +397,14 @@ func (cmd *DeleteObstacleCmd) redo(sb *Sandbox, ui *UiState) {
 	sb.RemoveObstacle(cmd.coord, cmd.board, cmd.obstacle)
 	ui.board = int32(cmd.board)
 	ui.selection.SelectCoord(cmd.coord)
+	ui.showShop = false
 }
 
 func (cmd *DeleteObstacleCmd) undo(sb *Sandbox, ui *UiState) {
 	sb.NewObstacle(cmd.coord, cmd.board, cmd.obstacle)
 	ui.board = int32(cmd.board)
 	ui.selection.SelectCoord(cmd.coord)
+	ui.showShop = false
 }
 
 type PastePieceCmd struct {
@@ -425,6 +449,7 @@ func (cmd *PastePieceCmd) redo(sb *Sandbox, ui *UiState) {
 		ui.board = int32(cmd.piece.board)
 	}
 	ui.selection.SelectPiece(cmd.piece.id)
+	ui.showShop = false
 }
 
 func (cmd *PastePieceCmd) undo(sb *Sandbox, ui *UiState) {
@@ -440,6 +465,7 @@ func (cmd *PastePieceCmd) undo(sb *Sandbox, ui *UiState) {
 	if cmd.piece.board != OffBoard {
 		ui.board = int32(cmd.piece.board)
 	}
+	ui.showShop = false
 }
 
 type DuplicatePieceCmd struct {
@@ -470,11 +496,13 @@ func (cmd *DuplicatePieceCmd) redo(sb *Sandbox, ui *UiState) {
 		sb.NewStatusEffect(cmd.piece.id, effect)
 	}
 	ui.selection.SelectPiece(cmd.piece.id)
+	ui.showShop = false
 }
 
 func (cmd *DuplicatePieceCmd) undo(sb *Sandbox, ui *UiState) {
 	sb.RemovePiece(cmd.piece.id)
 	ui.selection.SelectPiece(cmd.originalId)
+	ui.showShop = false
 }
 
 type ChangeColorOfPieceCmd struct {
@@ -497,9 +525,166 @@ func NewChangeColorOfPieceCmd(sb *Sandbox, id uint32, color PieceColor) ChangeCo
 func (cmd *ChangeColorOfPieceCmd) redo(sb *Sandbox, ui *UiState) {
 	sb.GetPiece(cmd.piece).color = cmd.after
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
 }
 
 func (cmd *ChangeColorOfPieceCmd) undo(sb *Sandbox, ui *UiState) {
 	sb.GetPiece(cmd.piece).color = cmd.before
 	ui.selection.SelectPiece(cmd.piece)
+	ui.showShop = false
+}
+
+type ChangeMoneyAmountCmd struct {
+	whiteBefore int
+	whiteAfter  int
+	blackBefore int
+	blackAfter  int
+}
+
+func NewChangeMoneyAmountCmd(ui *UiState, whiteNewAmount int, blackNewAmount int) ChangeMoneyAmountCmd {
+	var whiteBefore = ui.shop.money[0]
+	var blackBefore = ui.shop.money[1]
+	ui.shop.money[0] = whiteNewAmount
+	ui.shop.money[1] = blackNewAmount
+	return ChangeMoneyAmountCmd{
+		whiteBefore: whiteBefore,
+		whiteAfter:  whiteNewAmount,
+		blackBefore: blackBefore,
+		blackAfter:  blackNewAmount,
+	}
+}
+
+func (cmd *ChangeMoneyAmountCmd) redo(sb *Sandbox, ui *UiState) {
+	ui.shop.money[0] = cmd.whiteAfter
+	ui.shop.money[1] = cmd.blackAfter
+}
+
+func (cmd *ChangeMoneyAmountCmd) undo(sb *Sandbox, ui *UiState) {
+	ui.shop.money[0] = cmd.whiteBefore
+	ui.shop.money[1] = cmd.blackBefore
+}
+
+type ChangeShopUnlockCountCmd struct {
+	before int
+	after  int
+}
+
+func NewChangeShopUnlockCountCmd(ui *UiState, newCount int) ChangeShopUnlockCountCmd {
+	var before = ui.shop.unlockedCount
+	ui.shop.unlockedCount = newCount
+	return ChangeShopUnlockCountCmd{
+		before: before,
+		after:  newCount,
+	}
+}
+
+func (cmd *ChangeShopUnlockCountCmd) redo(sb *Sandbox, ui *UiState) {
+	ui.shop.unlockedCount = cmd.after
+	ui.showShop = true
+}
+
+func (cmd *ChangeShopUnlockCountCmd) undo(sb *Sandbox, ui *UiState) {
+	ui.shop.unlockedCount = cmd.before
+	ui.showShop = true
+}
+
+type ShuffleShopCmd struct {
+	swaps []int
+}
+
+func NewShuffleShopCmd(shop *Shop) ShuffleShopCmd {
+	// Fisher-Yates shuffle, but we store which indices we roll, so we can undo it
+	var swaps = make([]int, 0)
+	for i := len(shop.entries) - 1; i >= 1; i-- {
+		var j = rand.Intn(i + 1)
+		swaps = append(swaps, j)
+		shop.entries[i], shop.entries[j] = shop.entries[j], shop.entries[i]
+	}
+	return ShuffleShopCmd{
+		swaps: swaps,
+	}
+}
+
+func (cmd *ShuffleShopCmd) redo(sb *Sandbox, ui *UiState) {
+	for i := len(ui.shop.entries) - 1; i >= 1; i-- {
+		var j = cmd.swaps[len(ui.shop.entries)-1-i]
+		ui.shop.entries[i], ui.shop.entries[j] = ui.shop.entries[j], ui.shop.entries[i]
+	}
+	ui.showShop = true
+}
+
+func (cmd *ShuffleShopCmd) undo(sb *Sandbox, ui *UiState) {
+	for i := 1; i < len(ui.shop.entries); i++ {
+		var j = cmd.swaps[len(ui.shop.entries)-1-i]
+		ui.shop.entries[i], ui.shop.entries[j] = ui.shop.entries[j], ui.shop.entries[i]
+	}
+	ui.showShop = true
+}
+
+type ChangeShopEntryPriceCmd struct {
+	entry       uint32
+	priceBefore int
+	priceAfter  int
+}
+
+func NewChangeShopEntryPriceCmd(shop *Shop, entry uint32, newPrice int) ChangeShopEntryPriceCmd {
+	var e = shop.GetEntry(entry)
+	var priceBefore = e.price
+	e.price = newPrice
+	return ChangeShopEntryPriceCmd{
+		entry:       entry,
+		priceBefore: priceBefore,
+		priceAfter:  newPrice,
+	}
+}
+
+func (cmd *ChangeShopEntryPriceCmd) redo(sb *Sandbox, ui *UiState) {
+	ui.shop.GetEntry(cmd.entry).price = cmd.priceAfter
+	ui.showShop = true
+}
+
+func (cmd *ChangeShopEntryPriceCmd) undo(sb *Sandbox, ui *UiState) {
+	ui.shop.GetEntry(cmd.entry).price = cmd.priceBefore
+	ui.showShop = true
+}
+
+type QuickBuyCmd struct {
+	player uint32
+	entry  uint32
+	unlock bool
+}
+
+func NewQuickBuyCmd(shop *Shop, player uint32, entry uint32) QuickBuyCmd {
+	var e = shop.GetEntry(entry)
+	shop.money[player] -= e.price
+	e.price++
+	var unlock = shop.unlockedCount < len(shop.entries)
+	if unlock {
+		shop.unlockedCount++
+	}
+	return QuickBuyCmd{
+		player: player,
+		entry:  entry,
+		unlock: unlock,
+	}
+}
+
+func (cmd *QuickBuyCmd) redo(sb *Sandbox, ui *UiState) {
+	var e = ui.shop.GetEntry(cmd.entry)
+	ui.shop.money[cmd.player] -= e.price
+	e.price++
+	if cmd.unlock {
+		ui.shop.unlockedCount++
+	}
+	ui.showShop = true
+}
+
+func (cmd *QuickBuyCmd) undo(sb *Sandbox, ui *UiState) {
+	if cmd.unlock {
+		ui.shop.unlockedCount--
+	}
+	var e = ui.shop.GetEntry(cmd.entry)
+	e.price--
+	ui.shop.money[cmd.player] += e.price
+	ui.showShop = true
 }

--- a/command.go
+++ b/command.go
@@ -9,7 +9,7 @@ type CreatePieceCmd struct {
 	captureAfterCoord Vec2
 }
 
-func NewCreatePieceCmd(sb *Sandbox, typ uint32, color PieceColor, board uint32, coord Vec2) CreatePieceCmd {
+func NewCreatePieceCmd(sb *Sandbox, typ uint32, color PieceColor, board uint32, coord Vec2) *CreatePieceCmd {
 	var cmd = CreatePieceCmd{}
 	if IsOffBoard(coord) {
 		board = OffBoard
@@ -23,7 +23,7 @@ func NewCreatePieceCmd(sb *Sandbox, typ uint32, color PieceColor, board uint32, 
 		captured.coord = cmd.captureAfterCoord
 	}
 	cmd.piece = *sb.NewPiece(typ, color, board, coord)
-	return cmd
+	return &cmd
 }
 
 func (cmd *CreatePieceCmd) redo(sb *Sandbox, ui *UiState) {
@@ -62,7 +62,7 @@ type DeletePieceCmd struct {
 	effects []uint32
 }
 
-func NewDeletePieceCmd(sb *Sandbox, ui *UiState, id uint32) DeletePieceCmd {
+func NewDeletePieceCmd(sb *Sandbox, ui *UiState, id uint32) *DeletePieceCmd {
 	var cmd = DeletePieceCmd{
 		piece:   *sb.GetPiece(id),
 		effects: sb.GetStatusEffectsOnPiece(id),
@@ -70,7 +70,7 @@ func NewDeletePieceCmd(sb *Sandbox, ui *UiState, id uint32) DeletePieceCmd {
 
 	sb.RemovePiece(id)
 	ui.selection.Deselect()
-	return cmd
+	return &cmd
 }
 
 func (cmd *DeletePieceCmd) redo(sb *Sandbox, ui *UiState) {
@@ -107,7 +107,7 @@ type MovePieceCmd struct {
 	captureAfterCoord Vec2
 }
 
-func NewMovePieceCmd(sb *Sandbox, id uint32, destCoord Vec2, destBoard uint32) MovePieceCmd {
+func NewMovePieceCmd(sb *Sandbox, id uint32, destCoord Vec2, destBoard uint32) *MovePieceCmd {
 	var piece = sb.GetPiece(id)
 	if piece.board == destBoard && piece.coord == destCoord {
 		panic("A piece cannot be moved to where it already is")
@@ -132,7 +132,7 @@ func NewMovePieceCmd(sb *Sandbox, id uint32, destCoord Vec2, destBoard uint32) M
 	cmd.afterCoord = destCoord
 	piece.coord = destCoord
 	piece.board = destBoard
-	return cmd
+	return &cmd
 }
 
 func (cmd *MovePieceCmd) redo(sb *Sandbox, ui *UiState) {
@@ -172,9 +172,9 @@ type CreateStatusEffectCmd struct {
 	effect uint32
 }
 
-func NewCreateStatusEffectCmd(sb *Sandbox, piece uint32, effect uint32) CreateStatusEffectCmd {
+func NewCreateStatusEffectCmd(sb *Sandbox, piece uint32, effect uint32) *CreateStatusEffectCmd {
 	sb.NewStatusEffect(piece, effect)
-	return CreateStatusEffectCmd{
+	return &CreateStatusEffectCmd{
 		piece:  piece,
 		effect: effect,
 	}
@@ -205,9 +205,9 @@ type DeleteStatusEffectCmd struct {
 	effect uint32
 }
 
-func NewDeleteStatusEffectCmd(sb *Sandbox, piece uint32, effect uint32) DeleteStatusEffectCmd {
+func NewDeleteStatusEffectCmd(sb *Sandbox, piece uint32, effect uint32) *DeleteStatusEffectCmd {
 	sb.RemoveStatusEffect(piece, effect)
-	return DeleteStatusEffectCmd{
+	return &DeleteStatusEffectCmd{
 		piece:  piece,
 		effect: effect,
 	}
@@ -237,9 +237,9 @@ type IncreasePieceScaleCmd struct {
 	piece uint32
 }
 
-func NewIncreasePieceScaleCmd(sb *Sandbox, piece uint32) IncreasePieceScaleCmd {
+func NewIncreasePieceScaleCmd(sb *Sandbox, piece uint32) *IncreasePieceScaleCmd {
 	sb.GetPiece(piece).scale++
-	return IncreasePieceScaleCmd{
+	return &IncreasePieceScaleCmd{
 		piece: piece,
 	}
 }
@@ -268,9 +268,9 @@ type DecreasePieceScaleCmd struct {
 	piece uint32
 }
 
-func NewDecreasePieceScaleCmd(sb *Sandbox, piece uint32) DecreasePieceScaleCmd {
+func NewDecreasePieceScaleCmd(sb *Sandbox, piece uint32) *DecreasePieceScaleCmd {
 	sb.GetPiece(piece).scale--
-	return DecreasePieceScaleCmd{
+	return &DecreasePieceScaleCmd{
 		piece: piece,
 	}
 }
@@ -300,9 +300,9 @@ type CreateTileCmd struct {
 	coord Vec2
 }
 
-func NewCreateTileCmd(sb *Sandbox, board uint32, coord Vec2) CreateTileCmd {
+func NewCreateTileCmd(sb *Sandbox, board uint32, coord Vec2) *CreateTileCmd {
 	sb.NewTile(board, coord)
-	return CreateTileCmd{
+	return &CreateTileCmd{
 		board: board,
 		coord: coord,
 	}
@@ -327,9 +327,9 @@ type DeleteTileCmd struct {
 	coord Vec2
 }
 
-func NewDeleteTileCmd(sb *Sandbox, board uint32, coord Vec2) DeleteTileCmd {
+func NewDeleteTileCmd(sb *Sandbox, board uint32, coord Vec2) *DeleteTileCmd {
 	sb.RemoveTile(board, coord)
-	return DeleteTileCmd{
+	return &DeleteTileCmd{
 		board: board,
 		coord: coord,
 	}
@@ -355,9 +355,9 @@ type CreateObstacleCmd struct {
 	obstacle uint32
 }
 
-func NewCreateObstacleCmd(sb *Sandbox, coord Vec2, board uint32, obstacle uint32) CreateObstacleCmd {
+func NewCreateObstacleCmd(sb *Sandbox, coord Vec2, board uint32, obstacle uint32) *CreateObstacleCmd {
 	sb.NewObstacle(coord, board, obstacle)
-	return CreateObstacleCmd{
+	return &CreateObstacleCmd{
 		obstacle: obstacle,
 		board:    board,
 		coord:    coord,
@@ -384,9 +384,9 @@ type DeleteObstacleCmd struct {
 	obstacle uint32
 }
 
-func NewDeleteObstacleCmd(sb *Sandbox, coord Vec2, board uint32, obstacle uint32) DeleteObstacleCmd {
+func NewDeleteObstacleCmd(sb *Sandbox, coord Vec2, board uint32, obstacle uint32) *DeleteObstacleCmd {
 	sb.RemoveObstacle(coord, board, obstacle)
-	return DeleteObstacleCmd{
+	return &DeleteObstacleCmd{
 		obstacle: obstacle,
 		board:    board,
 		coord:    coord,
@@ -415,7 +415,7 @@ type PastePieceCmd struct {
 	captureAfterCoord Vec2
 }
 
-func NewPastePieceCmd(sb *Sandbox, ui *UiState, coord Vec2, board uint32) PastePieceCmd {
+func NewPastePieceCmd(sb *Sandbox, ui *UiState, coord Vec2, board uint32) *PastePieceCmd {
 	var cmd = PastePieceCmd{}
 	if IsOffBoard(coord) {
 		board = OffBoard
@@ -437,7 +437,7 @@ func NewPastePieceCmd(sb *Sandbox, ui *UiState, coord Vec2, board uint32) PasteP
 		sb.NewStatusEffect(piece.id, effect)
 	}
 	ui.selection.SelectPiece(cmd.piece.id)
-	return cmd
+	return &cmd
 }
 
 func (cmd *PastePieceCmd) redo(sb *Sandbox, ui *UiState) {
@@ -474,7 +474,7 @@ type DuplicatePieceCmd struct {
 	effects    []uint32
 }
 
-func NewDuplicatePieceCmd(sb *Sandbox, ui *UiState, id uint32) DuplicatePieceCmd {
+func NewDuplicatePieceCmd(sb *Sandbox, ui *UiState, id uint32) *DuplicatePieceCmd {
 	var original = sb.GetPiece(id)
 	var coord = sb.FindUnoccupiedOffBoardCoord()
 	var piece = sb.NewPiece(original.typ, original.color, OffBoard, coord)
@@ -483,7 +483,7 @@ func NewDuplicatePieceCmd(sb *Sandbox, ui *UiState, id uint32) DuplicatePieceCmd
 		sb.NewStatusEffect(piece.id, effect)
 	}
 	ui.selection.SelectPiece(piece.id)
-	return DuplicatePieceCmd{
+	return &DuplicatePieceCmd{
 		originalId: id,
 		piece:      *piece,
 		effects:    effects,
@@ -511,11 +511,11 @@ type ChangeColorOfPieceCmd struct {
 	after  PieceColor
 }
 
-func NewChangeColorOfPieceCmd(sb *Sandbox, id uint32, color PieceColor) ChangeColorOfPieceCmd {
+func NewChangeColorOfPieceCmd(sb *Sandbox, id uint32, color PieceColor) *ChangeColorOfPieceCmd {
 	piece := sb.GetPiece(id)
 	var before = piece.color
 	piece.color = color
-	return ChangeColorOfPieceCmd{
+	return &ChangeColorOfPieceCmd{
 		piece:  id,
 		before: before,
 		after:  color,
@@ -541,12 +541,12 @@ type ChangeMoneyAmountCmd struct {
 	blackAfter  int
 }
 
-func NewChangeMoneyAmountCmd(ui *UiState, whiteNewAmount int, blackNewAmount int) ChangeMoneyAmountCmd {
+func NewChangeMoneyAmountCmd(ui *UiState, whiteNewAmount int, blackNewAmount int) *ChangeMoneyAmountCmd {
 	var whiteBefore = ui.shop.money[0]
 	var blackBefore = ui.shop.money[1]
 	ui.shop.money[0] = whiteNewAmount
 	ui.shop.money[1] = blackNewAmount
-	return ChangeMoneyAmountCmd{
+	return &ChangeMoneyAmountCmd{
 		whiteBefore: whiteBefore,
 		whiteAfter:  whiteNewAmount,
 		blackBefore: blackBefore,
@@ -569,10 +569,10 @@ type ChangeShopUnlockCountCmd struct {
 	after  int
 }
 
-func NewChangeShopUnlockCountCmd(ui *UiState, newCount int) ChangeShopUnlockCountCmd {
+func NewChangeShopUnlockCountCmd(ui *UiState, newCount int) *ChangeShopUnlockCountCmd {
 	var before = ui.shop.unlockedCount
 	ui.shop.unlockedCount = newCount
-	return ChangeShopUnlockCountCmd{
+	return &ChangeShopUnlockCountCmd{
 		before: before,
 		after:  newCount,
 	}
@@ -592,7 +592,7 @@ type ShuffleShopCmd struct {
 	swaps []int
 }
 
-func NewShuffleShopCmd(shop *Shop) ShuffleShopCmd {
+func NewShuffleShopCmd(shop *Shop) *ShuffleShopCmd {
 	// Fisher-Yates shuffle, but we store which indices we roll, so we can undo it
 	var swaps = make([]int, 0)
 	for i := len(shop.entries) - 1; i >= 1; i-- {
@@ -600,7 +600,7 @@ func NewShuffleShopCmd(shop *Shop) ShuffleShopCmd {
 		swaps = append(swaps, j)
 		shop.entries[i], shop.entries[j] = shop.entries[j], shop.entries[i]
 	}
-	return ShuffleShopCmd{
+	return &ShuffleShopCmd{
 		swaps: swaps,
 	}
 }
@@ -627,11 +627,11 @@ type ChangeShopEntryPriceCmd struct {
 	priceAfter  int
 }
 
-func NewChangeShopEntryPriceCmd(shop *Shop, entry uint32, newPrice int) ChangeShopEntryPriceCmd {
+func NewChangeShopEntryPriceCmd(shop *Shop, entry uint32, newPrice int) *ChangeShopEntryPriceCmd {
 	var e = shop.GetEntry(entry)
 	var priceBefore = e.price
 	e.price = newPrice
-	return ChangeShopEntryPriceCmd{
+	return &ChangeShopEntryPriceCmd{
 		entry:       entry,
 		priceBefore: priceBefore,
 		priceAfter:  newPrice,
@@ -654,7 +654,7 @@ type QuickBuyCmd struct {
 	unlock bool
 }
 
-func NewQuickBuyCmd(shop *Shop, player uint32, entry uint32) QuickBuyCmd {
+func NewQuickBuyCmd(shop *Shop, player uint32, entry uint32) *QuickBuyCmd {
 	var e = shop.GetEntry(entry)
 	shop.money[player] -= e.price
 	e.price++
@@ -662,7 +662,7 @@ func NewQuickBuyCmd(shop *Shop, player uint32, entry uint32) QuickBuyCmd {
 	if unlock {
 		shop.unlockedCount++
 	}
-	return QuickBuyCmd{
+	return &QuickBuyCmd{
 		player: player,
 		entry:  entry,
 		unlock: unlock,

--- a/main.go
+++ b/main.go
@@ -56,7 +56,9 @@ func main() {
 
 		rl.BeginDrawing()
 		rl.ClearBackground(rl.RayWhite)
-		sandbox.Render(uint32(ui.board), false, &ui.selection)
+		if !ui.showShop {
+			sandbox.Render(uint32(ui.board), false, &ui.selection)
+		}
 		ui.Render(&undo)
 		rl.EndDrawing()
 	}

--- a/main.go
+++ b/main.go
@@ -75,23 +75,19 @@ func handleBoardInteraction(undo *UndoRedoSystem, ui *UiState) {
 
 	if pieceId, ok := ui.selection.GetSelectedPieceId(); ok && !ui.showShop {
 		if rl.IsKeyPressed(rl.KeyDelete) || rl.IsKeyPressed(rl.KeyBackspace) {
-			var cmd = NewDeletePieceCmd(&sandbox, ui, pieceId)
-			undo.Append(&cmd)
+			undo.Append(NewDeletePieceCmd(&sandbox, ui, pieceId))
 		} else if rl.IsKeyPressed(rl.KeyC) && ctrlDown {
 			var piece = sandbox.GetPiece(pieceId)
 			ui.clipboard.StorePiece(piece.typ, piece.color, piece.scale, sandbox.GetStatusEffectsOnPiece(pieceId))
 		} else if rl.IsKeyPressed(rl.KeyX) && ctrlDown {
 			var piece = sandbox.GetPiece(pieceId)
 			ui.clipboard.StorePiece(piece.typ, piece.color, piece.scale, sandbox.GetStatusEffectsOnPiece(pieceId))
-			var cmd = NewDeletePieceCmd(&sandbox, ui, pieceId)
-			undo.Append(&cmd)
+			undo.Append(NewDeletePieceCmd(&sandbox, ui, pieceId))
 		} else if rl.IsKeyReleased(rl.KeyD) && ctrlDown {
-			var cmd = NewDuplicatePieceCmd(&sandbox, ui, pieceId)
-			undo.Append(&cmd)
+			undo.Append(NewDuplicatePieceCmd(&sandbox, ui, pieceId))
 		} else if rl.IsKeyPressed(rl.KeyC) {
 			var newColor = 1 - sandbox.GetPiece(pieceId).color
-			var cmd = NewChangeColorOfPieceCmd(&sandbox, pieceId, newColor)
-			undo.Append(&cmd)
+			undo.Append(NewChangeColorOfPieceCmd(&sandbox, pieceId, newColor))
 		}
 	}
 
@@ -103,8 +99,7 @@ func handleBoardInteraction(undo *UndoRedoSystem, ui *UiState) {
 		if !ui.clipboard.isEmpty && !ui.showShop {
 			var coord = GetHoveredCoord()
 			if !IsCoordUnderUi(coord) {
-				var cmd = NewPastePieceCmd(&sandbox, ui, coord, uint32(ui.board))
-				undo.Append(&cmd)
+				undo.Append(NewPastePieceCmd(&sandbox, ui, coord, uint32(ui.board)))
 			}
 		}
 	}
@@ -135,14 +130,12 @@ func handleMouseInteraction(undo *UndoRedoSystem, ui *UiState) {
 		if rl.IsMouseButtonPressed(rl.MouseButtonRight) {
 			var piece = sandbox.GetPiece(id)
 			if piece.coord != coord || piece.board != uint32(ui.board) {
-				var cmd = NewMovePieceCmd(&sandbox, id, coord, uint32(ui.board))
-				undo.Append(&cmd)
+				undo.Append(NewMovePieceCmd(&sandbox, id, coord, uint32(ui.board)))
 			}
 		}
 	} else if id, ok := ui.selection.GetSelectedPieceTypeId(); ok {
 		if rl.IsMouseButtonPressed(rl.MouseButtonRight) {
-			var cmd = NewCreatePieceCmd(&sandbox, id, PieceColor(ui.color), uint32(ui.board), coord)
-			undo.Append(&cmd)
+			undo.Append(NewCreatePieceCmd(&sandbox, id, PieceColor(ui.color), uint32(ui.board), coord))
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func handleBoardInteraction(undo *UndoRedoSystem, ui *UiState) {
 
 	var ctrlDown = rl.IsKeyDown(rl.KeyLeftControl) || rl.IsKeyDown(rl.KeyLeftControl)
 
-	if pieceId, ok := ui.selection.GetSelectedPieceId(); ok {
+	if pieceId, ok := ui.selection.GetSelectedPieceId(); ok && !ui.showShop {
 		if rl.IsKeyPressed(rl.KeyDelete) || rl.IsKeyPressed(rl.KeyBackspace) {
 			var cmd = NewDeletePieceCmd(&sandbox, ui, pieceId)
 			undo.Append(&cmd)
@@ -100,7 +100,7 @@ func handleBoardInteraction(undo *UndoRedoSystem, ui *UiState) {
 	} else if rl.IsKeyPressed(rl.KeyY) && ctrlDown {
 		undo.Redo(&sandbox, ui)
 	} else if rl.IsKeyPressed(rl.KeyV) && ctrlDown {
-		if !ui.clipboard.isEmpty {
+		if !ui.clipboard.isEmpty && !ui.showShop {
 			var coord = GetHoveredCoord()
 			if !IsCoordUnderUi(coord) {
 				var cmd = NewPastePieceCmd(&sandbox, ui, coord, uint32(ui.board))
@@ -111,6 +111,10 @@ func handleBoardInteraction(undo *UndoRedoSystem, ui *UiState) {
 }
 
 func handleMouseInteraction(undo *UndoRedoSystem, ui *UiState) {
+	if ui.showShop {
+		return
+	}
+
 	var coord = GetHoveredCoord()
 	if IsCoordUnderUi(coord) {
 		return

--- a/shop.go
+++ b/shop.go
@@ -1,8 +1,6 @@
 package main
 
-import (
-	"math/rand"
-)
+import "math/rand"
 
 type ShopEntry struct {
 	id            uint32
@@ -37,7 +35,7 @@ func NewShop() Shop {
 	shop.AddEntry(2, "Forgive a piece for its sins.")
 	shop.AddEntry(8, "Spawn new Knight anywhere on your back rank.")
 	shop.AddEntry(10, "Spawn new Bishop anywhere on your back rank.")
-	shop.Shuffle()
+	rand.Shuffle(len(shop.entries), func(i, j int) { shop.entries[i], shop.entries[j] = shop.entries[j], shop.entries[i] })
 	return shop
 }
 
@@ -59,6 +57,11 @@ func (s *Shop) BlackMoney() *int {
 	return &s.money[1]
 }
 
-func (s *Shop) Shuffle() {
-	rand.Shuffle(len(s.entries), func(i, j int) { s.entries[i], s.entries[j] = s.entries[j], s.entries[i] })
+func (s *Shop) GetEntry(id uint32) *ShopEntry {
+	for i := 0; i < len(s.entries); i++ {
+		if s.entries[i].id == id {
+			return &s.entries[i]
+		}
+	}
+	return nil
 }

--- a/shop.go
+++ b/shop.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"math/rand"
+)
+
+type ShopEntry struct {
+	id            uint32
+	price         int
+	originalPrice int
+	description   string
+}
+
+type Shop struct {
+	money         [2]int
+	entries       []ShopEntry
+	unlockedCount int
+}
+
+func NewShop() Shop {
+	var shop = Shop{
+		unlockedCount: 3,
+	}
+	shop.AddEntry(6, "Stun a non-King piece for 3 rounds.")
+	shop.AddEntry(12, "Move a non-royal piece to Earth.")
+	shop.AddEntry(8, "Upgrade a non-royal piece.")
+	shop.AddEntry(6, "Plant a secret trap.")
+	shop.AddEntry(5, "Start a fire on an unoccupied tile.")
+	shop.AddEntry(20, "Kill a non-standard piece.")
+	shop.AddEntry(4, "Buy a chaos orb.")
+	shop.AddEntry(8, "Remove ice and fire in a 2x2 area.")
+	shop.AddEntry(6, "Curse a non-royal piece.")
+	shop.AddEntry(12, "Spawn new Rook anywhere on your back rank.")
+	shop.AddEntry(12, "Get two actions next turn.")
+	shop.AddEntry(6, "Move a piece t anywhere on the same plane.")
+	shop.AddEntry(6, "Freeze a 2x2 area.")
+	shop.AddEntry(2, "Forgive a piece for its sins.")
+	shop.AddEntry(8, "Spawn new Knight anywhere on your back rank.")
+	shop.AddEntry(10, "Spawn new Bishop anywhere on your back rank.")
+	shop.Shuffle()
+	return shop
+}
+
+func (s *Shop) AddEntry(price int, description string) *ShopEntry {
+	s.entries = append(s.entries, ShopEntry{
+		id:            uint32(len(s.entries)),
+		price:         price,
+		originalPrice: price,
+		description:   description,
+	})
+	return &s.entries[len(s.entries)-1]
+}
+
+func (s *Shop) WhiteMoney() *int {
+	return &s.money[0]
+}
+
+func (s *Shop) BlackMoney() *int {
+	return &s.money[1]
+}
+
+func (s *Shop) Shuffle() {
+	rand.Shuffle(len(s.entries), func(i, j int) { s.entries[i], s.entries[j] = s.entries[j], s.entries[i] })
+}

--- a/ui.go
+++ b/ui.go
@@ -54,6 +54,10 @@ func (s *UiState) Update() {
 	//var origo = GetBoardOrigo()
 	//var previewSourceOrigo = rl.NewVector2(float32(origo.x-TileSize), float32(origo.y-TileSize))
 
+	if s.showShop {
+		s.selection.Deselect()
+	}
+
 	if s.board != 0 || s.showShop {
 		rl.BeginTextureMode(s.renderTexHeaven)
 		rl.ClearBackground(rl.RayWhite)

--- a/ui.go
+++ b/ui.go
@@ -11,24 +11,32 @@ const (
 	UiMarginSmall    = 10
 	UiMarginBig      = 40
 	UiButtonH        = 36
+	UiButtonFlatH    = 30
+	UiButtonNarrowW  = 88
+	UiButtonW        = 136
+	UiButtonTinyW    = 36
 	UiRightMenuWidth = 155
+	UiShopWidth      = 660
 )
 
 type UiState struct {
 	selection       Selection
 	clipboard       Clipboard
+	shop            Shop
 	board           int32
 	tab             int32
 	color           int32
 	renderTexHeaven rl.RenderTexture2D
 	renderTexEarth  rl.RenderTexture2D
 	renderTexHell   rl.RenderTexture2D
+	showShop        bool
 }
 
 func NewUiState() UiState {
 	return UiState{
 		selection:       NewSelection(),
 		clipboard:       NewClipboard(),
+		shop:            NewShop(),
 		board:           int32(1),
 		renderTexHeaven: rl.LoadRenderTexture(WindowWidth, WindowHeight),
 		renderTexEarth:  rl.LoadRenderTexture(WindowWidth, WindowHeight),
@@ -46,20 +54,20 @@ func (s *UiState) Update() {
 	//var origo = GetBoardOrigo()
 	//var previewSourceOrigo = rl.NewVector2(float32(origo.x-TileSize), float32(origo.y-TileSize))
 
-	if s.board != 0 {
+	if s.board != 0 || s.showShop {
 		rl.BeginTextureMode(s.renderTexHeaven)
 		rl.ClearBackground(rl.RayWhite)
 		//rl.Translatef(previewSourceOrigo.X, previewSourceOrigo.Y, 0)
 		sandbox.Render(0, true, &s.selection)
 		rl.EndTextureMode()
 	}
-	if s.board != 1 {
+	if s.board != 1 || s.showShop {
 		rl.BeginTextureMode(s.renderTexEarth)
 		rl.ClearBackground(rl.RayWhite)
 		sandbox.Render(1, true, &s.selection)
 		rl.EndTextureMode()
 	}
-	if s.board != 2 {
+	if s.board != 2 || s.showShop {
 		rl.BeginTextureMode(s.renderTexHell)
 		rl.ClearBackground(rl.RayWhite)
 		sandbox.Render(2, true, &s.selection)
@@ -78,6 +86,15 @@ func (s *UiState) Render(undo *UndoRedoSystem) {
 		s.board++
 	} else if rl.IsKeyPressed(rl.KeyTab) {
 		s.board = (s.board + 1) % 3
+	}
+
+	s.RenderMoneyWidget()
+	if rl.IsKeyPressed(rl.KeyS) {
+		s.showShop = !s.showShop
+	}
+	if s.showShop {
+		s.RenderShop()
+		return
 	}
 
 	var oldTab = s.tab
@@ -107,7 +124,7 @@ func (s *UiState) Render(undo *UndoRedoSystem) {
 }
 
 func (s *UiState) RenderBoardPreview(index int32) {
-	if s.board == index {
+	if s.board == index && !s.showShop {
 		return
 	}
 
@@ -127,6 +144,7 @@ func (s *UiState) RenderBoardPreview(index int32) {
 
 	if rg.Button(buttonPlacement, "") {
 		s.board = index
+		s.showShop = false
 	}
 	rl.DrawTexturePro(previewTex, previewSourceRect, previewPlacement, rl.NewVector2(0, 0), 0, rl.White)
 	if rl.CheckCollisionPointRec(rl.GetMousePosition(), previewPlacement) {
@@ -135,13 +153,13 @@ func (s *UiState) RenderBoardPreview(index int32) {
 }
 
 func (s *UiState) RenderPiecesTab() {
-	s.color = rg.ToggleSlider(rl.NewRectangle(float32(rl.GetScreenWidth()-UiMargin-130), 2*UiMargin+UiButtonH, 130, UiButtonH), "White;Black", s.color)
+	s.color = rg.ToggleSlider(rl.NewRectangle(float32(rl.GetScreenWidth()-UiMargin-UiButtonW), 2*UiMargin+UiButtonH, UiButtonW, UiButtonH), "White;Black", s.color)
 	if rl.IsKeyPressed(rl.KeyC) {
 		s.color = 1 - s.color
 	}
 
 	for i := 0; i < len(sandbox.pieceTypes); i++ {
-		if rg.Toggle(rl.NewRectangle(float32(rl.GetScreenWidth()-UiMargin-130), float32(3*UiMargin+2*UiButtonH+i*(UiMarginSmall+UiButtonH)), 130, UiButtonH), sandbox.GetPieceType(uint32(i)).name, s.selection.IsPieceTypeSelected(uint32(i))) {
+		if rg.Toggle(rl.NewRectangle(float32(rl.GetScreenWidth()-UiMargin-UiButtonW), float32(3*UiMargin+2*UiButtonH+i*(UiMarginSmall+UiButtonH)), UiButtonW, UiButtonH), sandbox.GetPieceType(uint32(i)).name, s.selection.IsPieceTypeSelected(uint32(i))) {
 			s.selection.SelectPieceType(uint32(i))
 		}
 	}
@@ -181,9 +199,9 @@ func (s *UiState) RenderPieceContextMenu(undo *UndoRedoSystem) {
 		}
 	}
 
-	var posX = float32(rl.GetScreenWidth() - 130 - UiMargin)
+	var posX = float32(rl.GetScreenWidth() - UiButtonW - UiMargin)
 	var posY = float32(rl.GetScreenHeight() - UiMargin - UiButtonH)
-	var width = float32(130)
+	var width = float32(UiButtonW)
 	var height float32 = UiButtonH
 	if rg.Button(rl.NewRectangle(posX, posY, width, height), "Remove piece") {
 		var cmd = NewDeletePieceCmd(&sandbox, s, selectedPieceId)
@@ -218,9 +236,9 @@ func (s *UiState) RenderCoordContextMenu(undo *UndoRedoSystem) {
 		}
 	}
 
-	var posX = float32(rl.GetScreenWidth() - 130 - UiMargin)
+	var posX = float32(rl.GetScreenWidth() - UiButtonW - UiMargin)
 	var posY = float32(rl.GetScreenHeight() - UiMargin - UiButtonH)
-	var width = float32(130)
+	var width = float32(UiButtonW)
 	var height float32 = UiButtonH
 	if rg.Button(rl.NewRectangle(posX, posY-UiMarginSmall-UiButtonH, width, height), "Add tile") {
 		if sandbox.GetTile(uint32(s.board), coord) == nil {
@@ -236,21 +254,102 @@ func (s *UiState) RenderCoordContextMenu(undo *UndoRedoSystem) {
 
 func SpinnerWithIcon(x float32, y float32, text string, tex rl.Texture2D) int {
 	const (
-		buttonW  = 40
-		buttonH  = 30
 		spacing  = UiMarginSmall
 		iconSize = 32
 	)
 
 	var texScale = iconSize / float32(tex.Height)
-	rl.DrawTextureEx(tex, rl.NewVector2(x+buttonW+spacing+iconSize/2-texScale*float32(tex.Width/2), y+buttonH/2-texScale*float32(tex.Height)/2-3), 0, texScale, rl.White)
-	rl.DrawText(text, int32(x+buttonW+spacing+13), int32(y+buttonH/2+iconSize/2-3), 16, rl.Black)
+	rl.DrawTextureEx(tex, rl.NewVector2(x+UiButtonTinyW+spacing+iconSize/2-texScale*float32(tex.Width/2), y+UiButtonFlatH/2-texScale*float32(tex.Height)/2-3), 0, texScale, rl.White)
+	rl.DrawText(text, int32(x+UiButtonTinyW+spacing+13), int32(y+UiButtonFlatH/2+iconSize/2-3), 16, rl.Black)
 	var res = 0
-	if rg.Button(rl.NewRectangle(x, y, buttonW, buttonH), "--") {
+	if rg.Button(rl.NewRectangle(x, y, UiButtonTinyW, UiButtonFlatH), "--") {
 		res--
 	}
-	if rg.Button(rl.NewRectangle(x+buttonW+iconSize+2*spacing, y, buttonW, buttonH), "++") {
+	if rg.Button(rl.NewRectangle(x+UiButtonTinyW+iconSize+2*spacing, y, UiButtonTinyW, UiButtonFlatH), "++") {
 		res++
 	}
 	return res
+}
+
+func (s *UiState) RenderShop() {
+	const fontSize = 20
+	const unlockButtonW = 88
+	const incButtonH = 30
+	var posX = float32(rl.GetScreenWidth()/2 - UiShopWidth/2)
+	var posY = float32(180)
+	rl.DrawText("Shop", int32(posX), int32(posY-incButtonH-UiMarginSmall), fontSize, rl.Black)
+	for i := 0; i < len(s.shop.entries); i++ {
+		var entry = &s.shop.entries[i]
+		var posX = posX
+		if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "$W") {
+			*s.shop.WhiteMoney() -= entry.price
+			entry.price++
+			s.shop.unlockedCount++
+		}
+		posX += UiButtonH + UiMarginSmall
+		if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "$B") {
+			*s.shop.BlackMoney() -= entry.price
+			entry.price++
+			s.shop.unlockedCount++
+		}
+		posX += UiButtonH + UiMarginSmall
+		if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "++") {
+			entry.price++
+		}
+		posX += UiButtonH + UiMarginSmall
+		if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "--") && entry.price > 0 {
+			entry.price--
+		}
+		posX += UiButtonH + UiMargin
+		var text = fmt.Sprint(entry.price, ": ", entry.description)
+		var color = rl.Black
+		if i >= s.shop.unlockedCount {
+			color = rl.LightGray
+		}
+		rl.DrawText(text, int32(posX), int32(posY+incButtonH/2-fontSize/2), fontSize, color)
+		posY += incButtonH + UiMarginSmall
+	}
+	posY += UiMarginSmall
+	if rg.Button(rl.NewRectangle(posX, posY, unlockButtonW, UiButtonH), "Unlock") && s.shop.unlockedCount < len(s.shop.entries) {
+		s.shop.unlockedCount++
+	}
+	if rg.Button(rl.NewRectangle(posX+unlockButtonW+UiMarginSmall, posY, unlockButtonW, UiButtonH), "Lock") && s.shop.unlockedCount > 0 {
+		s.shop.unlockedCount--
+	}
+	if rg.Button(rl.NewRectangle(posX+2*unlockButtonW+2*UiMarginSmall, posY, unlockButtonW, UiButtonH), "Shuffle") {
+		s.shop.Shuffle()
+	}
+}
+
+func (s *UiState) RenderMoneyWidget() {
+	const fontSize = 20
+	const unlockButtonW = 88
+	const incButtonH = 30
+	var posX = float32(rl.GetScreenWidth()/2 - UiShopWidth/2)
+	var posY = float32(UiMargin)
+
+	// Row 1 (White)
+	if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "++") {
+		*s.shop.WhiteMoney()++
+	}
+	if rg.Button(rl.NewRectangle(posX+UiButtonH+UiMarginSmall, posY, UiButtonH, incButtonH), "--") {
+		*s.shop.WhiteMoney()--
+	}
+	rl.DrawText(fmt.Sprint("White money: ", *s.shop.WhiteMoney()), int32(posX+2*UiButtonH+UiMarginSmall+UiMargin), int32(posY+incButtonH/2-fontSize/2), fontSize, rl.Black)
+	s.showShop = rg.Toggle(rl.NewRectangle(posX+UiShopWidth-unlockButtonW, posY, unlockButtonW, UiButtonH), "Shop", s.showShop)
+	if rg.Button(rl.NewRectangle(posX+UiShopWidth-2*unlockButtonW-UiMarginSmall, posY, unlockButtonW, UiButtonH), "++Both") {
+		*s.shop.WhiteMoney()++
+		*s.shop.BlackMoney()++
+	}
+	posY += incButtonH + UiMarginSmall
+
+	// Row 2 (Black)
+	if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "++") {
+		*s.shop.BlackMoney()++
+	}
+	if rg.Button(rl.NewRectangle(posX+UiButtonH+UiMarginSmall, posY, UiButtonH, incButtonH), "--") {
+		*s.shop.BlackMoney()--
+	}
+	rl.DrawText(fmt.Sprint("Black money: ", *s.shop.BlackMoney()), int32(posX+2*UiButtonH+UiMarginSmall+UiMargin), int32(posY+incButtonH/2-fontSize/2), fontSize, rl.Black)
+	posY += incButtonH + UiMarginSmall
 }

--- a/ui.go
+++ b/ui.go
@@ -180,12 +180,10 @@ func (s *UiState) RenderPieceContextMenu(undo *UndoRedoSystem) {
 		var pieceScale = piece.scale
 		var change = SpinnerWithIcon(spinnerX, spinnerY, fmt.Sprint(pieceScale), assets.texPieceScale)
 		if change < 0 && pieceScale > 1 {
-			var cmd = NewDecreasePieceScaleCmd(&sandbox, selectedPieceId)
-			undo.Append(&cmd)
+			undo.Append(NewDecreasePieceScaleCmd(&sandbox, selectedPieceId))
 		}
 		if change > 0 {
-			var cmd = NewIncreasePieceScaleCmd(&sandbox, selectedPieceId)
-			undo.Append(&cmd)
+			undo.Append(NewIncreasePieceScaleCmd(&sandbox, selectedPieceId))
 		}
 	}
 
@@ -194,12 +192,10 @@ func (s *UiState) RenderPieceContextMenu(undo *UndoRedoSystem) {
 		var effectCount = sandbox.GetStatusEffectCount(selectedPieceId, effect.id)
 		var change = SpinnerWithIcon(spinnerX, spinnerY+float32(i*55)+55, fmt.Sprint(effectCount), effect.tex)
 		if change < 0 && effectCount > 0 {
-			var cmd = NewDeleteStatusEffectCmd(&sandbox, selectedPieceId, effect.id)
-			undo.Append(&cmd)
+			undo.Append(NewDeleteStatusEffectCmd(&sandbox, selectedPieceId, effect.id))
 		}
 		if change > 0 {
-			var cmd = NewCreateStatusEffectCmd(&sandbox, selectedPieceId, effect.id)
-			undo.Append(&cmd)
+			undo.Append(NewCreateStatusEffectCmd(&sandbox, selectedPieceId, effect.id))
 		}
 	}
 
@@ -208,15 +204,13 @@ func (s *UiState) RenderPieceContextMenu(undo *UndoRedoSystem) {
 	var width = float32(UiButtonW)
 	var height float32 = UiButtonH
 	if rg.Button(rl.NewRectangle(posX, posY, width, height), "Remove piece") {
-		var cmd = NewDeletePieceCmd(&sandbox, s, selectedPieceId)
-		undo.Append(&cmd)
+		undo.Append(NewDeletePieceCmd(&sandbox, s, selectedPieceId))
 	}
 
 	posY -= UiButtonH + UiMargin
 	if rg.Button(rl.NewRectangle(posX, posY, width, height), "Change color") {
 		var newColor = 1 - piece.color
-		var cmd = NewChangeColorOfPieceCmd(&sandbox, selectedPieceId, newColor)
-		undo.Append(&cmd)
+		undo.Append(NewChangeColorOfPieceCmd(&sandbox, selectedPieceId, newColor))
 	}
 }
 
@@ -231,12 +225,10 @@ func (s *UiState) RenderCoordContextMenu(undo *UndoRedoSystem) {
 		var obCount = sandbox.GetObstacleCount(coord, uint32(s.board), obt.id)
 		var change = SpinnerWithIcon(spinnerX, spinnerY+float32(i*55)+55, fmt.Sprint(obCount), obt.tex)
 		if change < 0 && obCount > 0 {
-			var cmd = NewDeleteObstacleCmd(&sandbox, coord, uint32(s.board), obt.id)
-			undo.Append(&cmd)
+			undo.Append(NewDeleteObstacleCmd(&sandbox, coord, uint32(s.board), obt.id))
 		}
 		if change > 0 {
-			var cmd = NewCreateObstacleCmd(&sandbox, coord, uint32(s.board), obt.id)
-			undo.Append(&cmd)
+			undo.Append(NewCreateObstacleCmd(&sandbox, coord, uint32(s.board), obt.id))
 		}
 	}
 
@@ -246,13 +238,11 @@ func (s *UiState) RenderCoordContextMenu(undo *UndoRedoSystem) {
 	var height float32 = UiButtonH
 	if rg.Button(rl.NewRectangle(posX, posY-UiMarginSmall-UiButtonH, width, height), "Add tile") {
 		if sandbox.GetTile(uint32(s.board), coord) == nil {
-			var cmd = NewCreateTileCmd(&sandbox, uint32(s.board), coord)
-			undo.Append(&cmd)
+			undo.Append(NewCreateTileCmd(&sandbox, uint32(s.board), coord))
 		}
 	}
 	if rg.Button(rl.NewRectangle(posX, posY, width, height), "Remove tile") {
-		var cmd = NewDeleteTileCmd(&sandbox, uint32(s.board), coord)
-		undo.Append(&cmd)
+		undo.Append(NewDeleteTileCmd(&sandbox, uint32(s.board), coord))
 	}
 }
 
@@ -286,23 +276,19 @@ func (s *UiState) RenderShop(undo *UndoRedoSystem) {
 		var entry = &s.shop.entries[i]
 		var posX = posX
 		if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "$W") {
-			var cmd = NewQuickBuyCmd(&s.shop, 0, entry.id)
-			undo.Append(&cmd)
+			undo.Append(NewQuickBuyCmd(&s.shop, 0, entry.id))
 		}
 		posX += UiButtonH + UiMarginSmall
 		if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "$B") {
-			var cmd = NewQuickBuyCmd(&s.shop, 1, entry.id)
-			undo.Append(&cmd)
+			undo.Append(NewQuickBuyCmd(&s.shop, 1, entry.id))
 		}
 		posX += UiButtonH + UiMarginSmall
 		if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "++") {
-			var cmd = NewChangeShopEntryPriceCmd(&s.shop, entry.id, entry.price+1)
-			undo.Append(&cmd)
+			undo.Append(NewChangeShopEntryPriceCmd(&s.shop, entry.id, entry.price+1))
 		}
 		posX += UiButtonH + UiMarginSmall
 		if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "--") && entry.price > 0 {
-			var cmd = NewChangeShopEntryPriceCmd(&s.shop, entry.id, entry.price-1)
-			undo.Append(&cmd)
+			undo.Append(NewChangeShopEntryPriceCmd(&s.shop, entry.id, entry.price-1))
 		}
 		posX += UiButtonH + UiMargin
 		var text = fmt.Sprint(entry.price, ": ", entry.description)
@@ -315,16 +301,13 @@ func (s *UiState) RenderShop(undo *UndoRedoSystem) {
 	}
 	posY += UiMarginSmall
 	if rg.Button(rl.NewRectangle(posX, posY, unlockButtonW, UiButtonH), "Unlock") && s.shop.unlockedCount < len(s.shop.entries) {
-		var cmd = NewChangeShopUnlockCountCmd(s, s.shop.unlockedCount+1)
-		undo.Append(&cmd)
+		undo.Append(NewChangeShopUnlockCountCmd(s, s.shop.unlockedCount+1))
 	}
 	if rg.Button(rl.NewRectangle(posX+unlockButtonW+UiMarginSmall, posY, unlockButtonW, UiButtonH), "Lock") && s.shop.unlockedCount > 0 {
-		var cmd = NewChangeShopUnlockCountCmd(s, s.shop.unlockedCount-1)
-		undo.Append(&cmd)
+		undo.Append(NewChangeShopUnlockCountCmd(s, s.shop.unlockedCount-1))
 	}
 	if rg.Button(rl.NewRectangle(posX+2*unlockButtonW+2*UiMarginSmall, posY, unlockButtonW, UiButtonH), "Shuffle") {
-		var cmd = NewShuffleShopCmd(&s.shop)
-		undo.Append(&cmd)
+		undo.Append(NewShuffleShopCmd(&s.shop))
 	}
 }
 
@@ -337,29 +320,24 @@ func (s *UiState) RenderMoneyWidget(undo *UndoRedoSystem) {
 
 	// Row 1 (White)
 	if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "++") {
-		var cmd = NewChangeMoneyAmountCmd(s, *s.shop.WhiteMoney()+1, *s.shop.BlackMoney())
-		undo.Append(&cmd)
+		undo.Append(NewChangeMoneyAmountCmd(s, *s.shop.WhiteMoney()+1, *s.shop.BlackMoney()))
 	}
 	if rg.Button(rl.NewRectangle(posX+UiButtonH+UiMarginSmall, posY, UiButtonH, incButtonH), "--") {
-		var cmd = NewChangeMoneyAmountCmd(s, *s.shop.WhiteMoney()-1, *s.shop.BlackMoney())
-		undo.Append(&cmd)
+		undo.Append(NewChangeMoneyAmountCmd(s, *s.shop.WhiteMoney()-1, *s.shop.BlackMoney()))
 	}
 	rl.DrawText(fmt.Sprint("White money: ", *s.shop.WhiteMoney()), int32(posX+2*UiButtonH+UiMarginSmall+UiMargin), int32(posY+incButtonH/2-fontSize/2), fontSize, rl.Black)
 	s.showShop = rg.Toggle(rl.NewRectangle(posX+UiShopWidth-unlockButtonW, posY, unlockButtonW, UiButtonH), "Shop", s.showShop)
 	if rg.Button(rl.NewRectangle(posX+UiShopWidth-2*unlockButtonW-UiMarginSmall, posY, unlockButtonW, UiButtonH), "++Both") {
-		var cmd = NewChangeMoneyAmountCmd(s, *s.shop.WhiteMoney()+1, *s.shop.BlackMoney()+1)
-		undo.Append(&cmd)
+		undo.Append(NewChangeMoneyAmountCmd(s, *s.shop.WhiteMoney()+1, *s.shop.BlackMoney()+1))
 	}
 	posY += incButtonH + UiMarginSmall
 
 	// Row 2 (Black)
 	if rg.Button(rl.NewRectangle(posX, posY, UiButtonH, incButtonH), "++") {
-		var cmd = NewChangeMoneyAmountCmd(s, *s.shop.WhiteMoney(), *s.shop.BlackMoney()+1)
-		undo.Append(&cmd)
+		undo.Append(NewChangeMoneyAmountCmd(s, *s.shop.WhiteMoney(), *s.shop.BlackMoney()+1))
 	}
 	if rg.Button(rl.NewRectangle(posX+UiButtonH+UiMarginSmall, posY, UiButtonH, incButtonH), "--") {
-		var cmd = NewChangeMoneyAmountCmd(s, *s.shop.WhiteMoney(), *s.shop.BlackMoney()-1)
-		undo.Append(&cmd)
+		undo.Append(NewChangeMoneyAmountCmd(s, *s.shop.WhiteMoney(), *s.shop.BlackMoney()-1))
 	}
 	rl.DrawText(fmt.Sprint("Black money: ", *s.shop.BlackMoney()), int32(posX+2*UiButtonH+UiMarginSmall+UiMargin), int32(posY+incButtonH/2-fontSize/2), fontSize, rl.Black)
 	posY += incButtonH + UiMarginSmall


### PR DESCRIPTION
![billede](https://github.com/NicEastvillage/ChessHeavenAndHell/assets/21122471/c0e41755-c5a5-402a-b679-c50bf521c50b)

The money is shown even when outside the shop.

The "$W" and "$B" buttons are for quick-buying that shop entry for white/black (spent money, increase price, unlock new option)

Resolves #34, resolves #35 